### PR TITLE
Added notifyReady event

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -35,6 +35,19 @@ Platform.init = function () {
 	});
 };
 
+Platform.prototype.notifyReady = function (callback) {
+	callback = callback || function () {
+		};
+
+	setImmediate(function () {
+		process.send({
+			type: 'ready'
+		});
+
+		callback();
+	});
+};
+
 Platform.prototype.sendResult = function (result, callback) {
 	callback = callback || function () {
 		};


### PR DESCRIPTION
The plugin should call the notifyReady event in order to notify the
parent process that initialization is done.